### PR TITLE
fix: Phone number validation, add: two sheets

### DIFF
--- a/loaders/xlsx-loader.js
+++ b/loaders/xlsx-loader.js
@@ -497,6 +497,23 @@ var StyleBuilder = function (options) {
 			o += '<formula1>=ISNUMBER(MATCH(&quot;*@*.???&quot;,'+validation.sqref.split(':')[0]+',0))</formula1>';
 			o += '</dataValidation>';
 		}
+		else if(validation.type == "phone"){
+			var formula = '<dataValidation type="custom" allowBlank="1" showInputMessage="1" showErrorMessage="1" sqref="' + validation.sqref + '">';
+			var _cell = validation.sqref.split(':')[0];
+			formula += '<formula1>OR(IFERROR(IF(LEN(' + _cell +
+			')=10,VALUE(' + _cell +
+			')*0 + 1,FALSE),FALSE), IFERROR(IF(OR(LEN(' + _cell +
+			')=12,LEN(' + _cell + 
+			')=13),IF(AND(MID(' + _cell +
+			',4,1)=&quot;-&quot;,MID(' + _cell + 
+			',8,1)=&quot;-&quot;),VALUE(LEFT(' + _cell + 
+			',3) &amp; MID(' + _cell + 
+			',5,3) &amp; MID(' + _cell + 
+			',9,32767)) * 0 + 1,FALSE),FALSE),FALSE))</formula1>';
+			formula += '</dataValidation>';
+			console.info(formula);
+			o += formula;
+		}
 		else if(validation.type == "phone_number"){
 			o += '<dataValidation type="custom" allowBlank="1" showInputMessage="1" showErrorMessage="1" sqref="' + validation.sqref + '">';
 			o += '<formula1>=AND(ISNUMBER(SUMPRODUCT(SEARCH(MID('+validation.sqref.split(':')[0]+',ROW(INDIRECT(&quot;1:&quot;&amp;LEN('+validation.sqref.split(':')[0]+'))),1),&quot;0123456789&quot;))),LEN('+validation.sqref.split(':')[0]+')=9,'+validation.sqref.split(':')[0]+'&lt;&gt;&quot;123456789&quot;,'+validation.sqref.split(':')[0]+'&lt;&gt;&quot;987654321&quot;,'+validation.sqref.split(':')[0]+'&lt;&gt;&quot;000000000&quot;)</formula1>';
@@ -521,8 +538,6 @@ module.exports = function(input) {
   input = input.replace(/function write_zip_type.+\{/, (a) => a + `
     style_builder  = new StyleBuilder(opts);
   `);
-  var write_sty_xml = input.indexOf('function get_cell_style');
-  write_sty_xml = input.substr(write_sty_xml - 100, 500);
   const needle = `write_ws_xml_merges(ws['!merges']`;
   const start = input.indexOf(needle);
   const nextLineIndex = input.indexOf('\n', start);

--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,6 @@ import logo from './logo.svg';
 import './App.css';
 /* eslint import/no-webpack-loader-syntax: off */
 import XLSX from '../loaders/xlsx-loader!xlsx';
-//import XLSX from 'data-validation-xlsx';
 import saveAs from 'file-saver';
 import XLSXDropZone from './XLSXDropZone';
 
@@ -27,7 +26,9 @@ class App extends Component {
       Author: 'Alexandru Faina',
       CreatedDate: new Date()
     };
-    wb.SheetNames.push('New Sheet');
+    wb.SheetNames.push('Intro');
+    wb.SheetNames.push('Instructions');
+    wb.SheetNames.push('Validation');
     var ws = XLSX.utils.json_to_sheet([
       { Student: 'Euan'},
       { Student: 'Mary'},
@@ -50,7 +51,7 @@ class App extends Component {
       {sqref: 'B2:B99', type: 'list', values: ['Maths', 'English', 'History', 'Geography', 'Art', 'Science', 'Computers', 'French']},
       {sqref: 'C2:C99', type: 'decimal', operator: 'between', min:1, max: 10},
       {sqref: 'D2:D99', type: 'email'},
-      {sqref: 'E2:E99', type: 'phone_number'},
+      {sqref: 'E2:E99', type: 'phone'},
       {sqref: 'F2:F99', type: 'date', operator: 'between', start: '1/1/1900', end: '12/31/3000'},
       {sqref: 'G2:G99', type: 'list', values: ['Male', 'Female']}
     ];
@@ -98,28 +99,42 @@ class App extends Component {
     }
     ws['!ref']='A1:G99';
 
-    wb.Sheets['New Sheet'] = ws;
-    wb.Sheets['Sheet 2'] = {
-      A1: {v: 'Sheet 2'}
-    };
-    Object.assign(window, {ws, wb});
+    wb.Sheets['Validation'] = ws;
+    wb.Sheets['Intro'] = {
+			A1: {
+				t: 's', v: 'Intro',
+				s: {
+					fill: {
+						fgColor: {
+							rgb: 'ffff00'
+						}
+					},
+				},
+			},
+			'!ref': 'A1:G9',
+		};
+		wb.Sheets['Instructions'] = {
+			A1: {t: 's', v: 'Instructions'},
+			'!ref': 'A1:G9',
+		};
+		Object.assign(window, {ws, wb});
 
-    var wbout = XLSX.write(wb, {bookType: 'xlsx', type:'binary'});
+		var wbout = XLSX.write(wb, {bookType: 'xlsx', type:'binary'});
 
-    saveAs(new Blob([this.s2ab(wbout)], {type: 'application/octet-stream'}), 'dropdown.xlsx');
-  }
-  render() {
-    return (
-      <div className='App'>
-        <header className='App-header'>
-          <img src={logo} className='App-logo' alt='logo' />
-          <h1 className='App-title'>Welcome to React</h1>
-        </header>
-        <button onClick={this.convert}>Convert</button>
+		saveAs(new Blob([this.s2ab(wbout)], {type: 'application/octet-stream'}), 'dropdown.xlsx');
+	}
+	render() {
+		return (
+			<div className='App'>
+				<header className='App-header'>
+					<img src={logo} className='App-logo' alt='logo' />
+					<h1 className='App-title'>Welcome to React</h1>
+				</header>
+				<button onClick={this.convert}>Convert</button>
 				<XLSXDropZone onChange={e => console.log(e)}/>
-      </div>
-    );
-  }
+			</div>
+		);
+	}
 }
 
 export default App;


### PR DESCRIPTION
The phone number validation:
The validation type should be `phone`, ex:
```
ws['!dataValidation'] =  [
   ...
   {sqref: 'E2:E99', type: 'phone'},
}
```
supported formats:  `1234567890`, `123-456-7890` and `123-456-78901`.

Two new sheets were added `intro` and `instructions`